### PR TITLE
Bump NuGet version 2.0, Fix constructor error

### DIFF
--- a/src/MTCAdapter.cs
+++ b/src/MTCAdapter.cs
@@ -169,7 +169,7 @@ namespace MTConnect
         public Adapter(int aPort = 7878, bool verbose = false)
         {
             mPort = aPort;
-            _commandsToSendOnConnect = new List<Tuple<MTConnectDeviceCommand, string>>
+            _commandsToSendOnConnect = new List<Tuple<MTConnectDeviceCommand, string>>();
             Heartbeat = 10000;
             Verbose = verbose;
         }

--- a/src/mtconnect_adapter_sdk.csproj
+++ b/src/mtconnect_adapter_sdk.csproj
@@ -5,7 +5,7 @@
 
     <!-- Generate a NuGet package-->
     <PackageId>mtconnect_adapter_sdk</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors></Authors>
     <Company></Company>
   </PropertyGroup>


### PR DESCRIPTION
To resolve a NuGet versioning conflict the minor version was bumped to 0.2.0.

Correcting error in MTCAdapter's constructor of the command replay list.