### PR TITLE
Reorder clientThread.Join() to last call as it blocks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ steps:
     command: custom
     custom: pack
     projects: ./src/mtconnect_adapter_sdk.csproj
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --version-suffix pr-$(Build.SourceVersion)'
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --version-suffix pr-$(Build.SourceVersion) --no-build'
 - task: DotNetCoreCLI@2
   displayName: 'Publish NuGet Package to mtconnect_sdk_feed'
   inputs:

--- a/src/MTCAdapter.cs
+++ b/src/MTCAdapter.cs
@@ -586,11 +586,11 @@ namespace MTConnect
                     clientThread.Start(client);
 
                     SendAllTo(client.GetStream());
-                    clientThread.Join();
                     foreach(Tuple<MTConnectDeviceCommand, string> tuple in _commandsToSendOnConnect)
                     {
                         SendCommand(tuple.Item1, tuple.Item2, false);
                     }
+                    clientThread.Join();
                 }
             }
             catch (Exception e)

--- a/src/mtconnect_adapter_sdk.csproj
+++ b/src/mtconnect_adapter_sdk.csproj
@@ -5,7 +5,7 @@
 
     <!-- Generate a NuGet package-->
     <PackageId>mtconnect_adapter_sdk</PackageId>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <Version>0.2.1</Version>
     <Authors></Authors>
     <Company></Company>
   </PropertyGroup>

--- a/src/mtconnect_adapter_sdk.csproj
+++ b/src/mtconnect_adapter_sdk.csproj
@@ -5,7 +5,7 @@
 
     <!-- Generate a NuGet package-->
     <PackageId>mtconnect_adapter_sdk</PackageId>
-    <Version>0.2.1</Version>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <Authors></Authors>
     <Company></Company>
   </PropertyGroup>


### PR DESCRIPTION
Calling this before the command update prevents it from firing even on disconnect. Reordering solves this issue.

Bump NuGet version to compensate