### PR TITLE
[bug] fix NuGet suffix naming based on build job trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,21 +27,25 @@ steps:
     echo 'OS: $(Agent.OS)'
     echo 'Build Directory: $(Agent.BuildDirectory)'
     echo 'Home Directory: $(Agent.HomeDirectory)'
-    echo '----------- Build information -----------'
+    echo '------------ Trigger Information --------------'
     echo 'Build Reason: $(Build.Reason)'
-    echo 'Source Branch Name: $(Build.SourceBranchName)'
+    echo 'Source Branch Name: $(Build.SourceBranch)'
     echo 'Commit Hash: $(Build.SourceVersion)'
+    echo '================ Commit Message ==============='
+    echo '$(Build.SourceVersionMessage)
+    echo '============== End Commit Message ============='
     echo 'PR Number: $(System.PullRequest.PullRequestNumber)'
+    echo '------------- Build Information ---------------'
     echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
   displayName: 'Log Variables of Interest'
 - bash: |
-    if [$(Build.Reason) == "Manual"]; then
+    if ["$(Build.Reason)" = "Manual"]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageManualSuffix)'
-    elif [$(Build.Reason) == "PullRequest"]; then
+    elif ["$(Build.Reason)" = "PullRequest"]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackagePRSuffix)'
-    elif [$(Build.Reason) == "IndividualCI"]; then
-      if [$(Build.SourceBranchName) == "master"]; then :
-      elif [$(Build.SourceBranchName) == "develop"]; then
+    elif ["$(Build.Reason)" = "IndividualCI"]; then
+      if ["$(Build.SourceBranchName)" = "master"]; then :
+      elif ["$(Build.SourceBranchName)" = "develop"]; then
         echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageDevelopSuffix)'
       else
         echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownCISuffix)'
@@ -49,6 +53,9 @@ steps:
     else
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownSuffix)'
     fi
+    echo '-----------------------------------------------'
+    echo 'NuGetPackageSuffix Value: $(NuGetPackageSuffix)'
+    echo '-----------------------------------------------'
   displayName: 'Update NuGet Package Suffix'
 - task: UseDotNet@2
   displayName: 'Install .NET Core sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
     echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
   displayName: 'Log Variables of Interest'
 - bash: |
-    if [$(Build.Reason) == "Manual")]; then
+    if [$(Build.Reason) == "Manual"]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageManualSuffix)'
     elif [$(Build.Reason) == "PullRequest"]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackagePRSuffix)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
     echo 'Source Branch Name: $(Build.SourceBranch)'
     echo 'Commit Hash: $(Build.SourceVersion)'
     echo '================ Commit Message ==============='
-    echo '$(Build.SourceVersionMessage)
+    echo '$(Build.SourceVersionMessage)'
     echo '============== End Commit Message ============='
     echo 'PR Number: $(System.PullRequest.PullRequestNumber)'
     echo '------------- Build Information ---------------'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,22 +23,6 @@ pool:
 
 steps:
 - bash: |
-    echo '----------- Build Agent Information -----------'
-    echo 'OS: $(Agent.OS)'
-    echo 'Build Directory: $(Agent.BuildDirectory)'
-    echo 'Home Directory: $(Agent.HomeDirectory)'
-    echo '------------ Trigger Information --------------'
-    echo 'Build Reason: $(Build.Reason)'
-    echo 'Source Branch Name: $(Build.SourceBranch)'
-    echo 'Commit Hash: $(Build.SourceVersion)'
-    echo '================ Commit Message ==============='
-    echo '$(Build.SourceVersionMessage)'
-    echo '============== End Commit Message ============='
-    echo 'PR Number: $(System.PullRequest.PullRequestNumber)'
-    echo '------------- Build Information ---------------'
-    echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
-  displayName: 'Log Variables of Interest'
-- bash: |
     if [ "$(Build.Reason)" = "Manual" ]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageManualSuffix)'
     elif [ "$(Build.Reason)" = "PullRequest" ]; then
@@ -53,10 +37,27 @@ steps:
     else
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownSuffix)'
     fi
+  displayName: 'Determine NuGet Package Semantic Name'
+- bash: |
+    echo '----------- Build Agent Information -----------'
+    echo 'OS: $(Agent.OS)'
+    echo 'Build Directory: $(Agent.BuildDirectory)'
+    echo 'Home Directory: $(Agent.HomeDirectory)'
+    echo '------------ Trigger Information --------------'
+    echo 'Build Reason: $(Build.Reason)'
+    echo 'Source Branch Name: $(Build.SourceBranch)'
+    echo 'Commit Hash: $(Build.SourceVersion)'
+    echo '================ Commit Message ==============='
+    echo '$(Build.SourceVersionMessage)'
+    echo '============== End Commit Message ============='
+    echo 'PR Number: $(System.PullRequest.PullRequestNumber)'
+    echo '------------- Build Information ---------------'
+    echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
+    echo '------------- NuGet Information ---------------'
     echo '-----------------------------------------------'
-    echo 'NuGetPackageSuffix Value: $(NuGetPackageSuffix)'
+    echo 'NuGetPackageSuffix: $(NuGetPackageSuffix)'
     echo '-----------------------------------------------'
-  displayName: 'Update NuGet Package Suffix'
+  displayName: 'Log Variables of Interest'
 - task: UseDotNet@2
   displayName: 'Install .NET Core sdk'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,13 +39,13 @@ steps:
     echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
   displayName: 'Log Variables of Interest'
 - bash: |
-    if ["$(Build.Reason)" = "Manual"]; then
+    if [ "$(Build.Reason)" = "Manual" ]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageManualSuffix)'
-    elif ["$(Build.Reason)" = "PullRequest"]; then
+    elif [ "$(Build.Reason)" = "PullRequest" ]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackagePRSuffix)'
-    elif ["$(Build.Reason)" = "IndividualCI"]; then
-      if ["$(Build.SourceBranchName)" = "master"]; then :
-      elif ["$(Build.SourceBranchName)" = "develop"]; then
+    elif [ "$(Build.Reason)" = "IndividualCI" ]; then
+      if [ "$(Build.SourceBranchName)" = "master" ]; then :
+      elif [ "$(Build.SourceBranchName)" = "develop" ]; then
         echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageDevelopSuffix)'
       else
         echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownCISuffix)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,25 +2,52 @@ variables:
   BuildConfiguration: Release
   BuildPlatform: AnyCPU
   NuGetPackageSuffix: ''
-  NuGetPackageDevelopSuffix: -prerelease
+  NuGetPackageDevelopSuffix: 'prerelease'
+  NuGetPackageManualSuffix: 'manual-$(Build.SourceVersion)'
   NuGetPackagePRSuffix: 'pr$(System.PullRequest.PullRequestNumber)-$(Build.BuildNumber)-$(Build.SourceVersion)'
+  NuGetPackageUnknownCISuffix: 'CI-unknown-$(Build.SourceVersion)'
+  NuGetPackageUnknownSuffix: 'UNKNOWN-$(Build.SourceVersion)'
 
 trigger:
-- develop
+  branches:
+    include:
+      - master
+      - develop
 
 pr:
 - develop
+- master
 
 pool:
   vmImage: 'vs2015-win2012r2'
 
 steps:
 - bash: |
-    if [$(Build.SourceBranchName) == "master"]; then :
-    elif [$(Build.SourceBranchName) == "develop"]; then
-      echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageDevelopSuffix)'
-    else
+    echo '----------- Build Agent Information -----------'
+    echo 'OS: $(Agent.OS)'
+    echo 'Build Directory: $(Agent.BuildDirectory)'
+    echo 'Home Directory: $(Agent.HomeDirectory)'
+    echo '----------- Build information -----------'
+    echo 'Build Reason: $(Build.Reason)'
+    echo 'Source Branch Name: $(Build.SourceBranchName)'
+    echo 'Commit Hash: $(Build.SourceVersion)'
+    echo 'PR Number: $(System.PullRequest.PullRequestNumber)'
+    echo 'Artifact staging directory: $(Build.ArtifactStagingDirectory)'
+  displayName: 'Log Variables of Interest'
+- bash: |
+    if [$(Build.Reason) == "Manual")]; then
+      echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageManualSuffix)'
+    elif [$(Build.Reason) == "PullRequest"]; then
       echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackagePRSuffix)'
+    elif [$(Build.Reason) == "IndividualCI"]; then
+      if [$(Build.SourceBranchName) == "master"]; then :
+      elif [$(Build.SourceBranchName) == "develop"]; then
+        echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageDevelopSuffix)'
+      else
+        echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownCISuffix)'
+      fi
+    else
+      echo '##vso[task.setvariable variable=NuGetPackageSuffix]$(NuGetPackageUnknownSuffix)'
     fi
   displayName: 'Update NuGet Package Suffix'
 - task: UseDotNet@2


### PR DESCRIPTION
A commit to develop after a PR was closed did not trigger a CI build. This is an attempt to be more explicit for both the develop branch and the master branch.

Triggering off a manual build does not indicate the branch that it came from, rather it does a detached HEAD which means it does not have a branch specifier. To correct this we catch if it is a Manual build reason.

To handle the inevitable unknown values that come from not having a local-installable version of Azure Pipelines we now complete the NuGet version suffix with defined unknown naming scheme.

Add logging to print out build variables of interest at the top of the job. This will be useful for creating a template build job in the future.