### PR TITLE
Extend support to dotnetstandard2.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Install .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 2.2.203
+    version: 3.1.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - task: GitVersion@5
   displayName: 'Update build/release version using GitVersion'

--- a/src/mtconnect_adapter_sdk.csproj
+++ b/src/mtconnect_adapter_sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net45</TargetFrameworks>
 
     <!-- Generate a NuGet package-->
     <PackageId>mtconnect_adapter_sdk</PackageId>

--- a/test/mtconnect_adapter_sdk.utests.csproj
+++ b/test/mtconnect_adapter_sdk.utests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>MTConnect.utests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Add build target to the sdk to netstandard2.1

Move the unit tests to dotnetcore3.1

Update azure-pipelines.yml to use the 3.1 dotnet sdk